### PR TITLE
Resolve telethon issues

### DIFF
--- a/archivers/base_archiver.py
+++ b/archivers/base_archiver.py
@@ -48,7 +48,7 @@ class Archiver(ABC):
         return self.get_key(urlparse(url).path.replace("/", "_") + ".html")
 
     def generate_media_page_html(self, url, urls_info: dict, object, thumbnail=None):
-        page = f'''<html><head><title>{url}</title></head>
+        page = f'''<html><head><title>{url}</title><meta charset="UTF-8"></head>
             <body>
             <h2>Archived media from {self.name}</h2>
             <h3><a href="{url}">{url}</a></h3><ul>'''
@@ -101,6 +101,7 @@ class Archiver(ABC):
             uploaded_media.append({'cdn_url': cdn_url, 'key': key, 'hash': hash})
 
         return self.generate_media_page_html(url, uploaded_media, object, thumbnail=thumbnail)
+
     def get_key(self, filename):
         """
         returns a key in the format "[archiverName]_[filename]" includes extension
@@ -178,7 +179,7 @@ class Archiver(ABC):
 
         key_thumb = cdn_urls[int(len(cdn_urls) * 0.1)]
 
-        index_page = f'''<html><head><title>{filename}</title></head>
+        index_page = f'''<html><head><title>{filename}</title><meta charset="UTF-8"></head>
             <body>'''
 
         for t in cdn_urls:

--- a/archivers/base_archiver.py
+++ b/archivers/base_archiver.py
@@ -56,7 +56,6 @@ class Archiver(ABC):
         for url_info in urls_info:
             page += f'''<li><a href="{url_info['cdn_url']}">{url_info['key']}</a>: {url_info['hash']}</li>'''
 
-        # TODO/ISSUE: character encoding is incorrect for Cyrillic, produces garbled text
         page += f"</ul><h2>{self.name} object data:</h2><code>{object}</code>"
         page += f"</body></html>"
 

--- a/archivers/telethon_archiver.py
+++ b/archivers/telethon_archiver.py
@@ -37,7 +37,7 @@ class TelethonArchiver(Archiver):
         posts = self.client.get_messages(chat, ids=search_ids)
         media = []
         for post in posts:
-            if post.grouped_id == original_post.grouped_id and post.media is not None:
+            if post is not None and post.grouped_id == original_post.grouped_id and post.media is not None:
                 media.append(post)
         return media
 

--- a/archivers/telethon_archiver.py
+++ b/archivers/telethon_archiver.py
@@ -2,7 +2,6 @@ import os
 import re
 import html
 from dataclasses import dataclass
-from urllib.parse import urlparse
 from loguru import logger
 
 from storages import Storage

--- a/archivers/telethon_archiver.py
+++ b/archivers/telethon_archiver.py
@@ -76,7 +76,7 @@ class TelethonArchiver(Archiver):
                 uploaded_media = []
                 message = post.message
                 for mp in media_posts:
-                    if len(mp.message) > message: message = mp.message
+                    if len(mp.message) > len(message): message = mp.message
                     filename = self.client.download_media(mp.media, f'tmp/{chat}_{group_id}/{mp.id}')
                     key = filename.split('tmp/')[1]
                     self.storage.upload(filename, key)

--- a/auto_archive.py
+++ b/auto_archive.py
@@ -78,8 +78,12 @@ def process_sheet(sheet, header=1, columns=GWorksheet.COLUMN_NAMES):
 
     options = webdriver.FirefoxOptions()
     options.headless = True
-    driver = webdriver.Firefox(options=options)
+    profile = webdriver.FirefoxProfile()
+    profile.set_preference('network.protocol-handler.external.tg', False)
+
+    driver = webdriver.Firefox(profile, options=options)
     driver.set_window_size(1400, 2000)
+    driver.set_page_load_timeout(10)
 
     # loop through worksheets to check
     for ii, wks in enumerate(sh.worksheets()):

--- a/auto_archive.py
+++ b/auto_archive.py
@@ -78,10 +78,9 @@ def process_sheet(sheet, header=1, columns=GWorksheet.COLUMN_NAMES):
 
     options = webdriver.FirefoxOptions()
     options.headless = True
-    profile = webdriver.FirefoxProfile()
-    profile.set_preference('network.protocol-handler.external.tg', False)
+    options.set_preference('network.protocol-handler.external.tg', False)
 
-    driver = webdriver.Firefox(profile, options=options)
+    driver = webdriver.Firefox(options=options)
     driver.set_window_size(1400, 2000)
     driver.set_page_load_timeout(10)
 

--- a/storages/s3_storage.py
+++ b/storages/s3_storage.py
@@ -20,6 +20,7 @@ class S3Storage(Storage):
         self.bucket = config.bucket
         self.region = config.region
         self.folder = config.folder
+        self.private = config.private
 
         if len(self.folder) and self.folder[-1] != '/':
             self.folder += '/'


### PR DESCRIPTION
- [x] Selenium driver not working for screenshots (however this fix uses a `FirefoxProfile` which has apparently been deprecated, so it would be nice to find a non-deprecated way to do this)
- [x] Message comparison weirdness, int vs str (fixed by adding another len, but not sure if this is the intended logic
- [x] Garbled Cyrillic text in HTML output -- possibly a character encoding issue when something is upload to S3
- [x] `post` can be None? This throws the error quoted below:

```
2022-03-18 11:06:22.340 | ERROR    | __main__:process_sheet:134 - Got unexpected error in row 2879 with archiver TelethonArchiver for url [...]: 'NoneType' object has no attribute 'grouped_id'
Traceback (most recent call last):
  File "/Volumes/Oxygen/auto-archiver/auto_archive.py", line 131, in process_sheet
    result = archiver.download(url, check_if_exists=True)
  File "/Volumes/Oxygen/auto-archiver/archivers/telethon_archiver.py", line 65, in download
    media_posts = self._get_media_posts_in_group(chat, post)
  File "/Volumes/Oxygen/auto-archiver/archivers/telethon_archiver.py", line 41, in _get_media_posts_in_group
    if post.grouped_id == original_post.grouped_id and post.media is not None:
AttributeError: 'NoneType' object has no attribute 'grouped_id'
```