### PR TITLE
Fixed wwww (4 w's) to www in youtubedl

### DIFF
--- a/archivers/youtubedl_archiver.py
+++ b/archivers/youtubedl_archiver.py
@@ -13,7 +13,7 @@ class YoutubeDLArchiver(Archiver):
 
     def download(self, url, check_if_exists=False):
         netloc = self.get_netloc(url)
-        if netloc in ['facebook.com', 'wwww.facebook.com'] and os.getenv('FB_COOKIE'):
+        if netloc in ['facebook.com', 'www.facebook.com'] and os.getenv('FB_COOKIE'):
             logger.info('Using Facebook cookie')
             yt_dlp.utils.std_headers['cookie'] = os.getenv('FB_COOKIE')
 


### PR DESCRIPTION
Could probably remove the wwww as `in` will always match on facebook.com.

https://stackoverflow.com/questions/3437059/does-python-have-a-string-contains-substring-method