### PR TITLE
youtubedl_archiver tweak for twitter.com to see if a linked video is there

### DIFF
--- a/archivers/youtubedl_archiver.py
+++ b/archivers/youtubedl_archiver.py
@@ -30,6 +30,13 @@ class YoutubeDLArchiver(Archiver):
         if info.get('is_live', False):
             logger.warning("Live streaming media, not archiving now")
             return ArchiveResult(status="Streaming media")
+        if 'twitter.com' in netloc:
+            if 'https://twitter.com/' in info['webpage_url']:
+                logger.info('Found https://twitter.com/ in the download url from Twitter')
+            else:
+                logger.info('Found a linked video probably in a link in a tweet - not getting that video as there may be images in the tweet')
+                return False
+
 
         if check_if_exists:
             if 'entries' in info:


### PR DESCRIPTION
…video is in there eg vk.com

For example in this Tweet

https://twitter.com/RALee85/status/1496790012242837506

There is a linked video to https://vk.com/milinfolive?w=wall-123538639_2215573

The assumption is the user meant the tweet and corresponding 4 images to be archived and not the linked video.

A Twitter embedded video https://twitter.com/FreeBurmaRangrs/status/1500900146216943621 will work as comes from twitter domain.