### PR TITLE
Empty entry number if using Google Storage catch

### DIFF
--- a/auto_archive.py
+++ b/auto_archive.py
@@ -93,6 +93,14 @@ def process_sheet(c: Config):
                 is_retry = Archiver.should_retry_from_status(status)
                 if not is_retry: continue
 
+            # if using folder based storage make sure an folder/Entry Number is specified eg MW0001
+            if c.storage == 'gd':
+                entry_number = gw.get_cell(row, 'folder')
+                # Some Slack integration writes a URL before an Entry Number is written so just leave for next time
+                if entry_number == "": 
+                    logger.warning(f'Missing entry number - waiting for next run')
+                    continue
+
             # All checks done - archival process starts here
             try:
                 gw.set_cell(row, 'status', 'Archive in progress')


### PR DESCRIPTION
A small change so that if using Google Drive and there is an empty entry number, which correlates to the new folder be created, it is ignored until the next run.

This is a 'normal' workflow under some conditions.