### PR TITLE
add csb_db config section to example.orchestration.yaml

### DIFF
--- a/example.orchestration.yaml
+++ b/example.orchestration.yaml
@@ -112,10 +112,11 @@ configurations:
     private: false
     # with 'random' you can generate a random UUID for the URL instead of a predictable path, useful to still have public but unlisted files, alternative is 'default' or not omitted from config
     key_path: random
-
   gdrive_storage:
     path_generator: url
     filename_generator: random
     root_folder_id: folder_id_from_url
     oauth_token: secrets/gd-token.json # needs to be generated with scripts/create_update_gdrive_oauth_token.py
     service_account: "secrets/service_account.json"
+  csv_db:
+    csv_file: "./local_archive/db.csv"


### PR DESCRIPTION
Added an example config section for csb_db to the example.orchestration.yaml file to clarify how to store info about what's been archived and also stores the archive result in a csv datastore