### PR TITLE
Extract text in wacz_enricher

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -35,6 +35,7 @@ vk-url-scraper = "*"
 requests = {extras = ["socks"], version = "*"}
 numpy = "*"
 warcio = "*"
+jsonlines = "*"
 
 [dev-packages]
 autopep8 = "*"


### PR DESCRIPTION
The enricher already passes the --text flag to browsertrix. This commit extracts and exposes it in the result metadata.

MVP for #107 