### PR TITLE
Optimize the Docker file - fixes #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,44 @@
-FROM webrecorder/browsertrix-crawler:1.0.4
+FROM webrecorder/browsertrix-crawler:1.0.4 AS base
 
-ENV RUNNING_IN_DOCKER=1
-
-WORKDIR /app
-
-RUN pip install --upgrade pip && \
-	pip install pipenv && \
-	add-apt-repository ppa:mozillateam/ppa && \
+RUN add-apt-repository ppa:mozillateam/ppa && \
 	apt-get update && \
-	apt-get install -y gcc ffmpeg fonts-noto exiftool && \
+	apt-get install -y --no-install-recommends gcc ffmpeg fonts-noto exiftool && \
 	apt-get install -y --no-install-recommends firefox-esr && \
 	ln -s /usr/bin/firefox-esr /usr/bin/firefox && \
 	wget https://github.com/mozilla/geckodriver/releases/download/v0.33.0/geckodriver-v0.33.0-linux64.tar.gz && \
 	tar -xvzf geckodriver* -C /usr/local/bin && \
 	chmod +x /usr/local/bin/geckodriver && \
-	rm geckodriver-v*
+	rm geckodriver-v* && \
+    rm -rf /var/lib/apt/lists/*
 
+FROM base AS pipenv
 
+ENV RUNNING_IN_DOCKER=1
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONFAULTHANDLER=1
+
+WORKDIR /
+
+RUN pip install pipenv
 COPY Pipfile* ./
+COPY Pipfile.lock .
 # install from pipenv, with browsertrix-only requirements
-RUN pipenv install
+RUN PIPENV_VENV_IN_PROJECT=1 pipenv install --deploy
+
+FROM base AS runtime
+
+WORKDIR /app
+
+# Copy virtual env built in pipenv stage
+COPY --from=pipenv /.venv /.venv
+ENV PATH="/.venv/bin:$PATH"
 
 # doing this at the end helps during development, builds are quick
-COPY ./src/ . 
+COPY ./src/ .
 
-ENTRYPOINT ["pipenv", "run", "python3", "-m", "auto_archiver"]
-
+ENTRYPOINT ["python3", "-m", "auto_archiver"]
+CMD ["--config", "secrets/orchestration.yaml"]
 # should be executed with 2 volumes (3 if local_storage is used)
 # docker run --rm -v $PWD/secrets:/app/secrets -v $PWD/local_archive:/app/local_archive aa pipenv run python3 -m auto_archiver --config secrets/orchestration.yaml


### PR DESCRIPTION
Hello,

This is an attempt to optimize the Docker file.
I noticed that the base image webrecorder/browsertrix-crawler weighs 2.44 Gb, which is already a lot, whereas the resulting auto-archiver image nearly doubles the size (4.29GB on my end). There is clearly some bloat.

I think we could improve this with multi-stage builds and remove some unwanted layers.

The proposed version should be functionally equivalent. The image size is 3.33GB on my end.
There is one stage that builds the virtual environment and copies it to the next layer. So, we can ditch pipenv and run Python directly. See the adapted entry point.

Another benefit of the multi-stage build is that if changes are made to the Python code, there is no need to rebuild the upper layers unless the requirements list has changed. Thanks to caching, generating a new Docker image will be quicker.

However, I need to stress that it’s not been tested thoroughly at all, and should be treated as a PoC to be validated before going to production.
