### PR TITLE
Make HashEnricher config optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ auto_archiver.egg-info*
 logs*
 *.csv
 archived/
+.idea/

--- a/src/auto_archiver/enrichers/hash_enricher.py
+++ b/src/auto_archiver/enrichers/hash_enricher.py
@@ -11,9 +11,20 @@ class HashEnricher(Enricher):
     """
     name = "hash_enricher"
 
-    def __init__(self, config: dict) -> None:
+    def __init__(self, config: dict = None) -> None:
+        final_config = {}
+        if not config:
+            # currently doesn't use user config in scenarios in which hash_enricher
+            # config is defined in yaml, but hash_enricher itself is not (as config
+            # parsing happens elsewhere)
+            he_configs = self.configs()
+            # handle potential future config options
+            for property_name in he_configs:
+                final_config[property_name] = he_configs[property_name]["default"]
+        else:
+            final_config = config
         # without this STEP.__init__ is not called
-        super().__init__(config)
+        super().__init__({self.name: final_config})
         algo_choices = self.configs()["algorithm"]["choices"]
         assert self.algorithm in algo_choices, f"Invalid hash algorithm selected, must be one of {algo_choices} (you selected {self.algorithm})."
         self.chunksize = int(self.chunksize)

--- a/src/auto_archiver/formatters/html_formatter.py
+++ b/src/auto_archiver/formatters/html_formatter.py
@@ -54,7 +54,17 @@ class HtmlFormatter(Formatter):
             outf.write(content)
         final_media = Media(filename=html_path, _mimetype="text/html")
 
-        he = HashEnricher({"hash_enricher": {"algorithm": ArchivingContext.get("hash_enricher.algorithm"), "chunksize": 1.6e7}})
+        # is defined when hash_enricher is included
+        if ArchivingContext.get("hash_enricher.algorithm"):
+            he = HashEnricher({"hash_enricher": {
+                "algorithm": ArchivingContext.get("hash_enricher.algorithm"),
+                "chunksize": 1.6e7 # could easily be redefined to pull from default config
+            }})
+        else:
+            # currently doesn't consider scenarios in which hash_enricher
+            # config is defined, but hash_enricher itself is not (as config
+            # parsing happens elsewhere)
+            he = HashEnricher()
         if len(hd := he.calculate_hash(final_media.filename)):
             final_media.set("hash", f"{he.algorithm}:{hd}")
 


### PR DESCRIPTION
Fixes #156. The same concept could be applied to `Step` itself, by updating `__init__()` with something like the following.
```
if config:
    for k, v in config.get(self.name, {}).items():
        self.__setattr__(k, v)
else: # allow initialization with default values
    for k, v in self.configs():
        self.__setattr__(k, v)
```
I wasn't sure of your preferences, so I figured I'd only add it where necessary for the time being, though I'm happy to refactor it.