### PR TITLE
Allow setting cookies for yt-dl

### DIFF
--- a/example.orchestration.yaml
+++ b/example.orchestration.yaml
@@ -94,6 +94,14 @@ configurations:
     password: "vk pass"
     session_file: "secrets/vk_config.v2.json"
 
+  youtubedl_archiver:
+    subtitles: true
+    # use one of the following two methods to authenticate in youtube - either provide a cookies file or use the cookies of the given browser
+    # for more information, see https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp
+    # cookie_file: "secrets/youtube_cookies.txt"
+    # cookies_from_browser: firefox
+    # proxy: socks5://proxy-user:password@proxy-ip:port
+
   screenshot_enricher:
     width: 1280
     height: 2300


### PR DESCRIPTION
Settings can be adjusted in orchestration.yml, with one of two options:

```
    # use one of the following two methods to authenticate in youtube - either provide a cookies file or use the cookies of the given browser
    # for more information, see https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp
    # cookie_file: "secrets/youtube_cookies.txt"
    # cookies_from_browser: firefox
```

Todo: create a PR template, to ensure the following are done:
1. Tests passing
2. Documentation updated [need documentation guideline - do we put documentation in orchestration.yml or in command line args config description?
3. Reviewer (at least 1 other person)