### PR TITLE
Add docker-compose for easy building and running of docker image in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,9 +277,9 @@ pytest -ra -v # or poetry run pytest -ra -v
 
 #### Docker development
 working with docker locally:
-  * `docker build . -t auto-archiver` to build a local image
-  * `docker run --rm -v $PWD/secrets:/app/secrets auto-archiver  --config secrets/orchestration.yaml`
-    * to use local archive, also create a volume `-v` for it by adding `-v $PWD/local_archive:/app/local_archive`
+  * `docker compose up` to build the first time and run a local image with the settings in `secrets/orchestration.yaml`
+  * To modify/pass additional command line args, use `docker compose run auto-archiver --config secrets/orchestration.yaml [OTHER ARGUMENTS]`
+  * To rebuild after code changes, just pass the `--build` flag, e.g. `docker compose up --build`
 
 
 manual release to docker hub

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: '3.8'
+
+services:
+  auto-archiver:
+  # point to the local dockerfile
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: auto-archiver
+    volumes:
+      - ./secrets:/app/secrets
+      - ./local_archive:/app/local_archive
+    environment:
+      - WACZ_ENABLE_DOCKER=true
+      - RUNNING_IN_DOCKER=true
+    command: --config secrets/orchestration.yaml


### PR DESCRIPTION
Just use `docker compose up` to build and run. It'll only regenerate an image if 