### PR TITLE
Docker webdriver aarch64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN add-apt-repository ppa:mozillateam/ppa && \
 	apt-get install -y --no-install-recommends firefox-esr && \
     ln -s /usr/bin/firefox-esr /usr/bin/firefox
 
-ARG GECKODRIVER_VERSION=0.35.0
+ARG GECKODRIVER_VERSION=0.36.0
 
 RUN if [ $(uname -m) = "aarch64" ]; then \
         GECKODRIVER_ARCH=linux-aarch64; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,26 @@ ENV RUNNING_IN_DOCKER=1 \
     PYTHONFAULTHANDLER=1 \
     PATH="/root/.local/bin:$PATH"
 
+
+ARG TARGETARCH
+
 # Installing system dependencies
 RUN add-apt-repository ppa:mozillateam/ppa && \
 	apt-get update && \
     apt-get install -y --no-install-recommends gcc ffmpeg fonts-noto exiftool && \
 	apt-get install -y --no-install-recommends firefox-esr && \
-    ln -s /usr/bin/firefox-esr /usr/bin/firefox && \
-    wget https://github.com/mozilla/geckodriver/releases/download/v0.35.0/geckodriver-v0.35.0-linux64.tar.gz && \
+    ln -s /usr/bin/firefox-esr /usr/bin/firefox
+
+ARG GECKODRIVER_VERSION=0.35.0
+
+RUN if [ $(uname -m) = "aarch64" ]; then \
+        GECKODRIVER_ARCH=linux-aarch64; \
+    else \
+        GECKODRIVER_ARCH=linux64; \
+    fi && \
+    wget https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-${GECKODRIVER_ARCH}.tar.gz && \
     tar -xvzf geckodriver* -C /usr/local/bin && \
     chmod +x /usr/local/bin/geckodriver && \
-    rm geckodriver-v* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN if [ $(uname -m) = "aarch64" ]; then \
     wget https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-${GECKODRIVER_ARCH}.tar.gz && \
     tar -xvzf geckodriver* -C /usr/local/bin && \
     chmod +x /usr/local/bin/geckodriver && \
+    rm geckodriver-v* && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/src/auto_archiver/core/base_module.py
+++ b/src/auto_archiver/core/base_module.py
@@ -105,8 +105,8 @@ class BaseModule(ABC):
             for key in self.authentication.keys():
                 if key in site or site in key:
                     logger.debug(f"Could not find exact authentication information for site '{site}'. \
-                                    did find information for '{key}' which is close, is this what you meant? \
-                                    If so, edit your authentication settings to make sure it exactly matches.")
+did find information for '{key}' which is close, is this what you meant? \
+If so, edit your authentication settings to make sure it exactly matches.")
 
         def get_ytdlp_cookiejar(args):
             import yt_dlp

--- a/src/auto_archiver/modules/screenshot_enricher/__manifest__.py
+++ b/src/auto_archiver/modules/screenshot_enricher/__manifest__.py
@@ -7,7 +7,7 @@
     },
     "configs": {
             "width": {"default": 1280, "help": "width of the screenshots"},
-            "height": {"default": 720, "help": "height of the screenshots"},
+            "height": {"default": 1024, "help": "height of the screenshots"},
             "timeout": {"default": 60, "help": "timeout for taking the screenshot"},
             "sleep_before_screenshot": {"default": 4, "help": "seconds to wait for the pages to load before taking screenshot"},
             "http_proxy": {"default": "", "help": "http proxy to use for the webdriver, eg http://proxy-user:password@proxy-ip:port"},

--- a/src/auto_archiver/utils/webdriver.py
+++ b/src/auto_archiver/utils/webdriver.py
@@ -9,8 +9,9 @@ from urllib.parse import urlparse, urlunparse
 from http.cookiejar import MozillaCookieJar
 
 from selenium import webdriver
-from selenium.common.exceptions import TimeoutException
-from selenium.webdriver.common.proxy import Proxy, ProxyType
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common import exceptions as selenium_exceptions
 from selenium.webdriver.common.print_page_options import PrintOptions
 from selenium.webdriver.common.by import By
 
@@ -78,19 +79,22 @@ class CookieSettingDriver(webdriver.Firefox):
         super(CookieSettingDriver, self).get(url)
         if self.facebook_accept_cookies:
             # try and click the 'close' button on the 'login' window to close it
-            close_button = self.find_element(By.XPATH, "//div[@role='dialog']//div[@aria-label='Close']")
-            if close_button:
-                close_button.click()
+            try:
+                xpath = "//div[@role='dialog']//div[@aria-label='Close']"
+                WebDriverWait(self, 5).until(EC.element_to_be_clickable((By.XPATH, xpath))).click()
+            except selenium_exceptions.NoSuchElementException:
+                logger.warning("Unable to find the 'close' button on the facebook login window")
+                pass
+
         else:
 
             # for all other sites, try and use some common button text to reject/accept cookies
             for text in ["Refuse non-essential cookies", "Decline optional cookies", "Reject additional cookies", "Accept all cookies"]:
                 try:
-                    accept_button = self.find_element(By.XPATH, f"//*[contains(translate(text(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '{text.lower()}')]")
-                    if accept_button:
-                        accept_button.click()
-                        break
-                except Exception as e:
+                    xpath = f"//*[contains(translate(text(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '{text.lower()}')]"
+                    WebDriverWait(self, 5).until(EC.element_to_be_clickable((By.XPATH, xpath))).click()
+                    break
+                except selenium_exceptions.WebDriverException:
                     pass
 
     
@@ -124,7 +128,7 @@ class Webdriver:
             self.driver.set_window_size(self.width, self.height)
             self.driver.set_page_load_timeout(self.timeout_seconds)
             self.driver.print_options = self.print_options
-        except TimeoutException as e:
+        except selenium_exceptions.TimeoutException as e:
             logger.error(f"failed to get new webdriver, possibly due to insufficient system resources or timeout settings: {e}")
 
         return self.driver

--- a/src/auto_archiver/utils/webdriver.py
+++ b/src/auto_archiver/utils/webdriver.py
@@ -72,6 +72,8 @@ class CookieSettingDriver(webdriver.Firefox):
                 time.sleep(2)
             except Exception as e:
                 logger.warning(f'Failed on fb accept cookies.', e)
+        
+
         # now get the actual URL
         super(CookieSettingDriver, self).get(url)
         if self.facebook_accept_cookies:
@@ -79,7 +81,17 @@ class CookieSettingDriver(webdriver.Firefox):
             close_button = self.find_element(By.XPATH, "//div[@role='dialog']//div[@aria-label='Close']")
             if close_button:
                 close_button.click()
+        else:
 
+            # for all other sites, try and use some common button text to reject/accept cookies
+            for text in ["Refuse non-essential cookies", "Decline optional cookies", "Reject additional cookies", "Accept all cookies"]:
+                try:
+                    accept_button = self.find_element(By.XPATH, f"//*[contains(translate(text(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), '{text.lower()}')]")
+                    if accept_button:
+                        accept_button.click()
+                        break
+                except Exception as e:
+                    pass
 
     
 class Webdriver:


### PR DESCRIPTION
This downloads the correct version of geckodriver depending on the Docker arch, fixing #232 

This was only an issue for people running on Mac with M1 chips.

Personally, I still vote for doing away with multiple archs for easier maintenance. Sure, maybe for Mac users (and linux ARM users - are there many?) it'll mean a slightly slower run, but 🤷‍♂️

If we remove ARM builds, it'll also a) speed up the docker build and b) mean we can remove the geckodriver update dance (selenium supports geckodriver for linux x86 out of the box)