### PR TITLE
Add cache-from and cache-to to docker-publish.yaml.

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -52,3 +52,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -45,7 +45,7 @@ jobs:
           images: bellingcat/auto-archiver
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Following the discussion in the issue here: https://github.com/bellingcat/auto-archiver/issues/212

This PR adds cache-from and cache-to to the docker-publish GH Actions workflow.

This should significantly reduce the build time.
The stats so far seem to be:

Push with no change: <1 min
Push with code change: ~4 mins
Push with requirements change: ~17 mins