### PR TITLE
Add flexible extractor_args to generic_extractor.py

### DIFF
--- a/src/auto_archiver/modules/generic_extractor/__manifest__.py
+++ b/src/auto_archiver/modules/generic_extractor/__manifest__.py
@@ -74,6 +74,11 @@ If you are having issues with the extractor, you can review the version of `yt-d
             "default": "inf",
             "help": "Use to limit the number of videos to download when a channel or long page is being extracted. 'inf' means no limit.",
         },
+        "extractor_args": {
+            "default": {},
+            "help": "Additional arguments to pass to the yt-dlp extractor. See https://github.com/yt-dlp/yt-dlp/blob/master/README.md#extractor-arguments.",
+            "type": "json_loader",
+        },
         "ytdlp_update_interval": {
             "default": 5,
             "help": "How often to check for yt-dlp updates (days). If positive, will check and update yt-dlp every [num] days. Set it to -1 to disable, or 0 to always update on every run.",

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -81,8 +81,20 @@ def test_load_modules(module_name):
     # check that default settings are applied
     default_config = module.configs
     assert loaded_module.name in loaded_module.config.keys()
+    defaults = {k for k in default_config}
+    assert defaults in [loaded_module.config[module_name].keys()]
+
+
+@pytest.mark.parametrize("module_name", ["local_storage", "generic_extractor", "html_formatter", "csv_db"])
+def test_config_defaults(module_name):
+    # test the values of the default config values are set
+    # Note: some modules can alter values in the setup() method, this test checks cases that don't
+    module = ModuleFactory().get_module_lazy(module_name)
+    loaded_module = module.load({})
+    # check that default config values are set
+    default_config = module.configs
     defaults = {k: v.get("default") for k, v in default_config.items()}
-    assert defaults.keys() in [loaded_module.config[module_name].keys()]
+    assert defaults == loaded_module.config[module_name]
 
 
 @pytest.mark.parametrize("module_name", ["local_storage", "generic_extractor", "html_formatter", "csv_db"])

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -82,7 +82,7 @@ def test_load_modules(module_name):
     default_config = module.configs
     assert loaded_module.name in loaded_module.config.keys()
     defaults = {k: v.get("default") for k, v in default_config.items()}
-    assert loaded_module.config[module_name] == defaults
+    assert defaults.keys() in [loaded_module.config[module_name].keys()]
 
 
 @pytest.mark.parametrize("module_name", ["local_storage", "generic_extractor", "html_formatter", "csv_db"])


### PR DESCRIPTION
Add option to add any [extractor args](https://github.com/yt-dlp/yt-dlp/blob/master/README.md#extractor-arguments) to the generic extractor.
This was added in preparation for passing proof of origin tokens, but separating it into it's own PR.