### PR TITLE
When loading modules, check they have been added to the right 'step' in the config

### DIFF
--- a/src/auto_archiver/core/module.py
+++ b/src/auto_archiver/core/module.py
@@ -85,7 +85,11 @@ class ModuleFactory:
         if not available:
             message = f"Module '{module_name}' not found. Are you sure it's installed/exists?"
             if "archiver" in module_name:
-                message += f" Did you mean {module_name.replace('archiver', 'extractor')}?"
+                message += f" Did you mean '{module_name.replace('archiver', 'extractor')}'?"
+            elif "gsheet" in module_name:
+                message += " Did you mean 'gsheet_feeder_db'?"
+            elif "atlos" in module_name:
+                message += " Did you mean 'atlos_feeder_db_storage'?"
             raise IndexError(message)
         return available[0]
 

--- a/tests/data/test_modules/example_extractor/__manifest__.py
+++ b/tests/data/test_modules/example_extractor/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    # Display Name of your module
+    "name": "Example Extractor",
+    # Optional version number, for your own versioning purposes
+    "version": 2.0,
+    # The type of the module, must be one (or more) of the built in module types
+    "type": ["extractor"],
+    # a boolean indicating whether or not a module requires additional user setup before it can be used
+    # for example: adding API keys, installing additional software etc.
+    "requires_setup": False,
+}

--- a/tests/data/test_modules/example_extractor/example_extractor.py
+++ b/tests/data/test_modules/example_extractor/example_extractor.py
@@ -1,0 +1,6 @@
+from auto_archiver.core import Extractor
+
+
+class ExampleExtractor(Extractor):
+    def download(self, item):
+        print("download")

--- a/tests/extractors/test_generic_extractor.py
+++ b/tests/extractors/test_generic_extractor.py
@@ -206,10 +206,11 @@ class TestGenericExtractor(TestExtractorBase):
 
         self.assertValidResponseMetadata(
             post,
-            "Onion rings are just vegetable donuts.",
+            "Cookie Monster - Onion rings are just vegetable donuts.",
             datetime.datetime(2023, 1, 24, 16, 25, 51, tzinfo=datetime.timezone.utc),
             "yt-dlp_Twitter: success",
         )
+        assert post.get("content") == "Onion rings are just vegetable donuts."
 
     @pytest.mark.download
     def test_twitter_download_video(self, make_item):

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -4,6 +4,7 @@ from auto_archiver.core.orchestrator import ArchivingOrchestrator
 from auto_archiver.version import __version__
 from auto_archiver.core.config import read_yaml, store_yaml
 from auto_archiver.core import Metadata
+from auto_archiver.core.consts import SetupError
 
 TEST_ORCHESTRATION = "tests/data/test_orchestration.yaml"
 TEST_MODULES = "tests/data/test_modules/"
@@ -224,3 +225,15 @@ def test_multiple_orchestrator(test_args):
     output: Metadata = list(o2.feed())
     assert len(output) == 1
     assert output[0].get_url() == "https://example.com"
+
+
+def test_wrong_step_type(test_args, caplog):
+    args = test_args + [
+        "--feeders",
+        "example_extractor",  # example_extractor is not a valid feeder!
+    ]
+
+    orchestrator = ArchivingOrchestrator()
+    with pytest.raises(SetupError) as err:
+        orchestrator.setup(args)
+        assert "Module 'example_extractor' is not a feeder" in str(err.value)


### PR DESCRIPTION
Fixes an issue seen on discord where a user accidentally set up metadata_enricher under 'extractors'

https://discord.com/channels/709752884257882135/1346596825611632770/1351336725070483477

To reproduce/test add 'gsheets_db_feeder' to 'extractor' step (or any other module to the wrong step)

Edit: Also fixes a small bug I saw in the Twitter dropin