### PR TITLE
Download tests

### DIFF
--- a/.github/workflows/tests-download.yaml
+++ b/.github/workflows/tests-download.yaml
@@ -10,9 +10,6 @@ on:
     workflows: ["Core Tests"]
     types:
       - completed
-    branches: [main]
-    paths:
-      - src/**
 
 jobs:
   tests:
@@ -30,7 +27,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+          # For PRs, use the head commit SHA from the triggering workflow
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+          # If PR is from a fork, we need fetch-depth: 0
+          fetch-depth: ${{ github.event.workflow_run.head_repository.fork && '0' || '1' }}
 
       - name: Install poetry
         run: pipx install poetry

--- a/src/auto_archiver/core/module.py
+++ b/src/auto_archiver/core/module.py
@@ -214,7 +214,7 @@ class LazyBaseModule:
 
         # check external dependencies are installed
         def check_deps(deps, check):
-            for dep in filter(lambda d: len(d.strip()), deps):
+            for dep in filter(lambda d: len(d.strip()) > 0, deps):
                 if not check(dep.strip()):
                     logger.error(
                         f"Module '{self.name}' requires external dependency '{dep}' which is not available/setup. \


### PR DESCRIPTION
I realised my previous CI changes didn't work correctly because it was set to `branches: [main]` only.

This hopefully fixes that, meaning the download CI tests run after the core tests have passed.