### PR TITLE
Changed log level on gsheet_feeder_db started from warning to info

### DIFF
--- a/src/auto_archiver/modules/gsheet_feeder_db/gsheet_feeder_db.py
+++ b/src/auto_archiver/modules/gsheet_feeder_db/gsheet_feeder_db.py
@@ -98,7 +98,7 @@ class GsheetsFeederDB(Feeder, Database):
         return missing
 
     def started(self, item: Metadata) -> None:
-        logger.warning(f"STARTED {item}")
+        logger.info(f"STARTED {item}")
         gw, row = self._retrieve_gsheet(item)
         gw.set_cell(row, "status", "Archive in progress")
 


### PR DESCRIPTION
Have started exploring the new excellent v1 release, and thought I'd do very small PR's of tweaks. Feel free to ignore if I've misunderstood anything.

In this case I feel that starting a run is more of an information level.