### PR TITLE
catch for if self.comments are true but no actual comments in video

### DIFF
--- a/src/auto_archiver/modules/generic_extractor/generic_extractor.py
+++ b/src/auto_archiver/modules/generic_extractor/generic_extractor.py
@@ -304,9 +304,11 @@ class GenericExtractor(Extractor):
             result.set_content(video_data["description"])
         # extract comments if enabled
         if self.comments:
-            result.set(
-                "comments",
-                [
+            # If self.comments are true but no comments in the video_data
+            if video_data.get("comments", []) is not None:
+                result.set(
+                    "comments",
+                    [
                     {
                         "text": c["text"],
                         "author": c["author"],


### PR DESCRIPTION
For this test case: https://www.youtube.com/watch?v=C0DPdy98e4c

The comments are turned off, so I added a catch to make sure otherwise aa threw an exception.