### PR TITLE
Small documentation typo correction; adding double-dash to poetry CL instruction

### DIFF
--- a/docs/source/development/developer_guidelines.md
+++ b/docs/source/development/developer_guidelines.md
@@ -21,7 +21,7 @@ This allows you to run the auto-archiver without the `poetry run` prefix.
 ### Optional Development Packages
 
 Install development packages (used for unit tests etc.) using:
-`poetry install -with dev`
+`poetry install --with dev`
 
 
 ```{toctree}


### PR DESCRIPTION
I totally understand if this is too small of a change to warrant a PR. I was charging through getting the development packages installed and copied and pasted the command for `poetry install -with dev`. Poetry needs a second dash before the `--with` flag, so I added it in. 

Again, I know this is an incredibly small fix! Please advise if there's a better way of addressing the typo. Thx.