### PR TITLE
updating the style-checking code in the documentation

### DIFF
--- a/docs/source/development/style_guide.md
+++ b/docs/source/development/style_guide.md
@@ -50,7 +50,7 @@ Note not all warnings can be fixed automatically.
 
 Most fixes are safe, but some non-standard practices such as dynamic loading are not picked up by linters. Ensure you check any modifications by this before committing them.
 ```shell
-make ruff-fix
+make ruff-clean
 ```
 
 **Changing Configurations ⚙️**


### PR DESCRIPTION
ruff-fix -> ruff-clean; there is no ruff-fix in the default Makefile. Maybe the command /should/ be ruff-fix to align with the underlying ruff command; that might be for a later discussion. This at least reconciles the documentation to the default Makefile