### PR TITLE
Add Deno to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG TARGETARCH
 
 # Installing system dependencies
 RUN	apt-get update && \
-    apt-get install -y --no-install-recommends gcc ffmpeg fonts-noto exiftool python3-tk curl unzip 
+    apt-get install -y --no-install-recommends gcc ffmpeg fonts-noto exiftool python3-tk
 
 # Poetry and runtime
 FROM base AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ ENV RUNNING_IN_DOCKER=1 \
     LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONFAULTHANDLER=1 \
-    PATH="/root/.local/bin:$PATH"
+    PYTHONFAULTHANDLER=1
 
 
 ARG TARGETARCH
@@ -26,9 +25,6 @@ ENV POETRY_NO_INTERACTION=1 \
 RUN python3 -m venv /poetry-venv && \
     /poetry-venv/bin/python -m pip install --upgrade pip && \
     /poetry-venv/bin/python -m pip install "poetry>=2.0.0,<3.0.0"
-
-# Add Deno for solving YT JS challenges
-RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr sh
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG TARGETARCH
 
 # Installing system dependencies
 RUN	apt-get update && \
-    apt-get install -y --no-install-recommends gcc ffmpeg fonts-noto exiftool python3-tk 
+    apt-get install -y --no-install-recommends gcc ffmpeg fonts-noto exiftool python3-tk curl unzip 
 
 # Poetry and runtime
 FROM base AS runtime
@@ -26,6 +26,9 @@ ENV POETRY_NO_INTERACTION=1 \
 RUN python3 -m venv /poetry-venv && \
     /poetry-venv/bin/python -m pip install --upgrade pip && \
     /poetry-venv/bin/python -m pip install "poetry>=2.0.0,<3.0.0"
+
+# Add Deno for solving YT JS challenges
+RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr sh
 
 WORKDIR /app
 

--- a/src/auto_archiver/modules/generic_extractor/generic_extractor.py
+++ b/src/auto_archiver/modules/generic_extractor/generic_extractor.py
@@ -575,6 +575,8 @@ class GenericExtractor(Extractor):
             "--live-from-start" if self.live_from_start else "--no-live-from-start",
             "--postprocessor-args",
             "ffmpeg:-bitexact",  # ensure bitexact output to avoid mismatching hashes for same video
+            "--js-runtimes",
+            "node",  # yt-dlp defaults to deno-only; node is available in the base image
         ]
 
         # proxy handling


### PR DESCRIPTION
This adds the Deno JavaScript runtime to the container to provide a backend for `yt-dlp-ejs` to use to solve YouTube JS challenges. This enables `auto-archiver` to have access to higher quality formats than may otherwise be available.

I would welcome guidance as to whether this is the appropriate install method for this, or whether pinning to a specific release is considered more appropriate.