### PR TITLE
Removes 'video unavailable' from YouTube deletion indicators

### DIFF
--- a/src/auto_archiver/utils/deletion_detection.py
+++ b/src/auto_archiver/utils/deletion_detection.py
@@ -64,7 +64,6 @@ class DeletionIndicators:
     # YouTube deletion indicators
     YOUTUBE = [
         "This video isn't available anymore",
-        "Video unavailable",
         "This video has been removed",
         "This video is no longer available",
         "This video is private",


### PR DESCRIPTION
This change removes `video unavailable` from the YouTube deletion indicators. The YouTube watch page HTML content now contains `"download_unplayable":"video unavailable offline"` and other instances of this string in a list of JavaScript language strings (a very long line 18). This appears to be on all English language YouTube watch pages from my testing.

Consequently, when the `antibot_extractor_enricher` is enabled, it will always detect the YouTube video as having been deleted and incorrectly documents that the video was deleted or otherwise made unavailable by its owner.